### PR TITLE
Add automerge schedule

### DIFF
--- a/default.json
+++ b/default.json
@@ -19,7 +19,10 @@
         "pin",
         "digest"
       ],
-      "automerge": true
+      "automerge": true,
+      "automergeSchedule": [
+        "schedule:daily"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Resolves #4

I just set [`automergeSchedule` option](https://docs.renovatebot.com/configuration-options/#automergeschedule) as `"schedule:daily"`, which means `"before 2am"` ([ref](https://docs.renovatebot.com/presets-schedule/)).

Of course, I ran `pnpm run test` and `default.json` was valid.
