### PR TITLE
Update schedule for PR creation and automerge

### DIFF
--- a/default.json
+++ b/default.json
@@ -21,7 +21,10 @@
       ],
       "automerge": true,
       "automergeSchedule": [
-        "schedule:daily"
+        "after 1am and before 2am"
+      ],
+      "schedule": [
+        "after 2am and before 3am"
       ]
     }
   ]


### PR DESCRIPTION
Improve #6

With this PR, Renovate will merge PRs during 1 a.m. through 2 a.m., and then create PR(s) during 2 a.m. through 3 a.m.
Being created after merging, PRs are kept open for 24 hours, during which we can take some actions as needed like closing.

I will merge this PR later (even without approval) to confirm the configuration is right, so please let me know later if you want to change the schedule.

Refs:

- https://docs.renovatebot.com/configuration-options/#schedule
- https://github.com/renovatebot/renovate/discussions/19889