### PR TITLE
fix: disable node engine updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,6 +11,7 @@
   "npm": {
     "commitMessageTopic": "{{prettyDepType}} {{depName}}"
   },
+  "ignoreDeps": ["node"],
   "packageRules": [
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
Renovate automatically bumps Node engine requirement, which is not desired: https://github.com/unjs/unimport/pull/421